### PR TITLE
update for elm 0.17

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.1.1",
+    "version": "1.1.2",
     "summary": "Elm module for (advanced) number formatting. Numeral.js port to Elm",
     "repository": "https://github.com/ggb/numeral-elm.git",
     "license": "MIT",
@@ -16,7 +16,8 @@
         "Languages.Italian"
     ],
     "dependencies": {
-        "elm-lang/core": "3.0.0 <= v < 4.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "evancz/elm-graphics": "1.0.0 <= v < 2.0.0"
     },
-    "elm-version": "0.16.0 <= v < 0.17.0"
+    "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/src/Language.elm
+++ b/src/Language.elm
@@ -1,4 +1,4 @@
-module Language (Language, Ordinal) where
+module Language exposing(Language, Ordinal)
 
 {-| Type definition for language configurations.
 

--- a/src/Languages/English.elm
+++ b/src/Languages/English.elm
@@ -1,4 +1,4 @@
-module Languages.English (lang) where
+module Languages.English exposing(lang)
 
 {-| English language configuration.
 

--- a/src/Languages/French.elm
+++ b/src/Languages/French.elm
@@ -1,4 +1,4 @@
-module Languages.French (lang) where
+module Languages.French exposing(lang)
 
 {-| French language configuration.
 

--- a/src/Languages/German.elm
+++ b/src/Languages/German.elm
@@ -1,4 +1,4 @@
-module Languages.German (lang) where
+module Languages.German exposing(lang)
 
 {-| German language configuration.
 

--- a/src/Languages/Italian.elm
+++ b/src/Languages/Italian.elm
@@ -1,4 +1,4 @@
-module Languages.Italian (lang) where
+module Languages.Italian exposing(lang)
 
 {-| Italian language configuration.
 

--- a/src/Languages/Japanese.elm
+++ b/src/Languages/Japanese.elm
@@ -1,4 +1,4 @@
-module Languages.Japanese (lang) where
+module Languages.Japanese exposing(lang)
 
 {-| Japanese language configuration.
 
@@ -14,7 +14,7 @@ japaneseOrdinal number =
 
 
 {-| Configuration data.
-  
+
     lang =
       { delimiters=
         { thousands=","

--- a/src/Numeral.elm
+++ b/src/Numeral.elm
@@ -1,4 +1,4 @@
-module Numeral (format, formatWithLanguage) where
+module Numeral exposing(format, formatWithLanguage)
 
 {-| Elm module for (advanced) number formatting. It is a direct port of [Numeral.js](http://numeraljs.com/) and it is possible to use the same format strings. Manipulation and unformatting of numbers is not yet supported.
 
@@ -65,7 +65,7 @@ formatCurrency lang format value strValue =
           [ currencySymbol
           , space
           , if String.contains "-" formatted then "-" else ""
-          , if String.contains "(" formatted then "(" else ""          
+          , if String.contains "(" formatted then "(" else ""
           , String.slice 1 (String.length formatted) formatted
           ] |> String.join ""
         else
@@ -195,7 +195,7 @@ checkByte format value =
         if value >= minValue && value < maxValue then
           if minValue > 0 then
             (power, value / minValue)
-          else 
+          else
             (power, value)
         else if power < 10 then
           suffixIndex' (power + 1)
@@ -286,7 +286,7 @@ processPrecision lang format value precision =
             lang.delimiters.decimal ++ y
           else
             ""
-        _ -> 
+        _ ->
           ""
     w =
       String.split "." fst
@@ -301,9 +301,9 @@ processPrecision lang format value precision =
 
 addThousandsDelimiter : Language -> String -> String
 addThousandsDelimiter lang word =
-  Regex.replace 
-    All 
-    (regex "(\\d)(?=(\\d{3})+(?!\\d))") 
+  Regex.replace
+    All
+    (regex "(\\d)(?=(\\d{3})+(?!\\d))")
     (\{match} -> match ++ lang.delimiters.thousands)
     word
 
@@ -312,7 +312,7 @@ formatNumber : NumberTypeFormatter
 formatNumber lang format value strValue =
   let
     (format', negP, signed) = checkParensAndSign format
-    (format'', abbr, value') = checkAbbreviation lang format' value 
+    (format'', abbr, value') = checkAbbreviation lang format' value
     (format''', value'', bytes) = checkByte format'' value'
     -- this is a stupid mess...
     (format'''', ord) = checkOrdinal lang format''' value''
@@ -328,7 +328,7 @@ formatNumber lang format value strValue =
       |> List.head
       |> Maybe.withDefault ""
     (w', d) = processPrecision lang format value'' precision
-    d' = 
+    d' =
       let
         result =
           String.slice 1 (String.length d) d
@@ -340,17 +340,17 @@ formatNumber lang format value strValue =
           ""
         else
           d
-    w'' = 
+    w'' =
       if String.contains "," finalFormat then
         addThousandsDelimiter lang w'
       else
         w'
-    (w''', neg) = 
+    (w''', neg) =
       if String.contains "-" w'' then
         (String.slice 1 (String.length w'') w'', True)
       else
         (w'', False)
-    finalWord = 
+    finalWord =
       if indexOf "." finalFormat == 0 then
         ""
       else
@@ -373,11 +373,11 @@ formatNumber lang format value strValue =
   in
     [ fst parens
     , minus
-    , plus 
+    , plus
     , finalWord
     , d'
-    , ord 
-    , abbr 
+    , ord
+    , abbr
     , bytes
     , snd parens
     ] |> String.join ""

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,7 +1,8 @@
-import Graphics.Element exposing (Element)
 import Numeral
 
+import Html exposing(..)
 import ElmTest exposing (..)
+import String
 
 numbers =
   [
@@ -147,8 +148,8 @@ timeTest =
 --  |> suite "Tests for rounding"
 
 
-main : Element
-main =
+tests : String
+tests =
   suite "Numeral"
       [ numbersTest
       , currencyTest
@@ -156,4 +157,18 @@ main =
       , percentagesTest
       , timeTest
       ]
-  |> elementRunner
+  |> stringRunner
+
+main : Html String
+main =
+  let
+    lines = String.lines tests
+  in
+    div [ ] (List.map (\s -> line s) lines)
+
+line : String -> Html String
+line s =
+  div [ ] [
+    text s,
+    br [ ] [ ]
+  ]

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "deadfoxygrandpa/elm-test": "3.1.1 <= v < 4.0.0",
-        "elm-lang/core": "3.0.0 <= v < 4.0.0"
+        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-lang/html": "1.0.0 <= v < 2.0.0"
     },
-    "elm-version": "0.16.0 <= v < 0.17.0"
+    "elm-version": "0.17.0 <= v < 0.18.0"
 }


### PR DESCRIPTION
I've updated both the package and its tests - **they pass!**, however tests now don't use Graphics.Element, since `elementRunner` got removed from elm-community/elm-test.

I tested breaking one of the tests and the result look like this:

```
6 suites run, containing 69 tests
4 suites and 68 tests passed
2 suites and 1 tests failed

Test Suite: Numeral: FAILED
Test Suite: Tests for numbers: all tests passed
Test Suite: Tests for currency: FAILED
"$1,000.23" == "$1,000.23": passed.
"$ 1,001" == "$ 1,001": passed.
"1,000.23 $" == "1,000.23 $": passed.
"($1,000)" == "($1,000)": passed.
"(1,000$)" == "(1,000$)": passed.
"-$1000.23" == "-$1000.23": passed.
"$1.23 m" == "$1.23 m": passed.
"$ (1,000)" == "$ (1,000)": passed.
"$(1,000)" == "$(1,000)": passed.
"$ (1,000.23)" == "$ (1,000.23)": passed.
"$(1,000.232)" == "$(1,000.23)": FAILED. Expected: "$(1,000.232)"; got: "$(1,000.23)"
"$(1,000.24)" == "$(1,000.24)": passed.
"$-1,000" == "$-1,000": passed.
"$ -1,000" == "$ -1,000": passed.
"$ 1,000" == "$ 1,000": passed.
"$1,000" == "$1,000": passed.
"$ 1,000.23" == "$ 1,000.23": passed.
"$1,000.23" == "$1,000.23": passed.
"$1,000.24" == "$1,000.24": passed.
"$1,000" == "$1,000": passed.
"$ 1,000" == "$ 1,000": passed.
Test Suite: Tests for bytes: all tests passed
Test Suite: Tests for percentages: all tests passed
Test Suite: Tests for time: all tests passed
```
