### PR TITLE
Add Spanish to the exposed modules

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -7,13 +7,14 @@
     "exposed-modules": [
         "Numeral",
         "Language",
-        "Languages.English",
         "Languages.BritishEnglish",
-        "Languages.German",
+        "Languages.English",
         "Languages.French",
-        "Languages.Japanese",
+        "Languages.German",
         "Languages.Italian",
+        "Languages.Japanese",
         "Languages.Russian",
+        "Languages.Spanish",
         "Languages.Ukrainian"
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",


### PR DESCRIPTION
Reorder exposed modules to be alphabetical, and add the **missing** Spanish language to the list.